### PR TITLE
Empty input fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,18 +103,20 @@ def menu():
             paint(f'\n    {language["script"]["INPUT"]}', end='')
             arguments = input().split()
 
-            try:
-                command = arguments[0].lower()
+            if len(arguments) > 0:
 
-                if command not in commands:
+                try:
+                    command = arguments[0].lower()
+
+                    if command not in commands:
+                        paint(f'\n    {language["script"]["PREFIX"]}{language["other_messages"]["INVALID_COMMAND"]}')
+
+                    if command in commands and check_command_arguments(command, arguments):
+                        change_last_command(command)
+                        commands[command](*arguments[1:])
+
+                except IndexError:
                     paint(f'\n    {language["script"]["PREFIX"]}{language["other_messages"]["INVALID_COMMAND"]}')
-                
-                if command in commands and check_command_arguments(command, arguments):
-                    change_last_command(command)
-                    commands[command](*arguments[1:])
-
-            except IndexError:
-                paint(f'\n    {language["script"]["PREFIX"]}{language["other_messages"]["INVALID_COMMAND"]}')
 
         except EOFError:
             pass


### PR DESCRIPTION
Now when a user writes nothing and presses enter, It will show again 'root@mcptool:~/MCPTool/ > ' instead of 'Incorrect command', just like a normal terminal